### PR TITLE
refactor(cart): simplify cart item handling and update pagination logic

### DIFF
--- a/src/main/java/com/trendistashop/dto/response/CartResponseDTO.java
+++ b/src/main/java/com/trendistashop/dto/response/CartResponseDTO.java
@@ -24,11 +24,7 @@ public class CartResponseDTO {
     private Object items;
     // === OPTION 1: Không phân trang ===
     public static CartResponseDTO fromEntity(Cart cart, ProductService productService) {
-        List<CartItem> sortedItems = cart.getCartItems().stream()
-                .sorted(Comparator.comparing(CartItem::getCreatedAt).reversed())
-                .toList();
-
-        List<CartItemDTO> itemDTOs = sortedItems.stream()
+        List<CartItemDTO> itemDTOs = cart.getCartItems().stream()
                 .map(item -> CartItemDTO.fromEntity(item, productService))
                 .collect(Collectors.toList());
 
@@ -37,22 +33,21 @@ public class CartResponseDTO {
 
     // === OPTION 2: Có phân trang ===
     public static CartResponseDTO fromEntity(Cart cart, ProductService productService, Pageable pageable) {
-        List<CartItem> sortedItems = cart.getCartItems().stream()
-                .sorted(Comparator.comparing(CartItem::getCreatedAt).reversed())
-                .toList();
+        List<CartItem> items = cart.getCartItems();
+        int total = items.size();
+        int pageSize = Math.max(1, pageable.getPageSize());
+        int start = Math.min((int) pageable.getOffset(), total);
+        int end = Math.min(start + pageSize, total);
 
-        int start = Math.min((int) pageable.getOffset(), sortedItems.size());
-        int end = Math.min(start + pageable.getPageSize(), sortedItems.size());
-
-        List<CartItemDTO> pagedItems = sortedItems.subList(start, end).stream()
+        List<CartItemDTO> pagedItems = items.subList(start, end).stream()
                 .map(item -> CartItemDTO.fromEntity(item, productService))
                 .collect(Collectors.toList());
 
         PageDTO<CartItemDTO> pageDTO = new PageDTO<>();
         pageDTO.setPage(pageable.getPageNumber());
-        pageDTO.setSize(pageable.getPageSize());
-        pageDTO.setTotal(sortedItems.size());
-        pageDTO.setTotalPage((int) Math.ceil((double) sortedItems.size() / pageable.getPageSize()));
+        pageDTO.setSize(pageSize);
+        pageDTO.setTotal(total);
+        pageDTO.setTotalPage((int) Math.ceil((double) total / pageSize));
         pageDTO.setContent(pagedItems);
         return new CartResponseDTO(cart.getId(), cart.getCartTotal(), pageDTO);
     }

--- a/src/main/java/com/trendistashop/entities/user/Cart.java
+++ b/src/main/java/com/trendistashop/entities/user/Cart.java
@@ -20,6 +20,7 @@ public class Cart extends BaseEntity {
     @GeneratedValue
     private UUID id;
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "cart", fetch = FetchType.EAGER, orphanRemoval = true)
+    @OrderBy("createdAt DESC")
     @EqualsAndHashCode.Exclude
     private List<CartItem> cartItems ;
     private BigDecimal cartTotal = BigDecimal.ZERO;

--- a/src/main/java/com/trendistashop/services/ICartService.java
+++ b/src/main/java/com/trendistashop/services/ICartService.java
@@ -12,6 +12,5 @@ public interface ICartService {
     public TypeResponse<CartResponseDTO> addProductToCart(CartDTO cart, Principal principal) ;
     public TypeResponse<CartResponseDTO> getCartProduct (Principal principal, Pageable pageable);
     public TypeResponse<CartResponseDTO> removeProductFromCart(CartDTO cartDTO, Principal principal);
-    public TypeResponse<Cart> changeQuantity(CartDTO cartDTO , Principal principal, int quantity);
     public TypeResponse<CartResponseDTO> clearCart(Principal principal);
 }

--- a/src/main/java/com/trendistashop/services/impl/order/CartService.java
+++ b/src/main/java/com/trendistashop/services/impl/order/CartService.java
@@ -176,11 +176,6 @@ public class CartService implements ICartService {
     }
 
     @Override
-    public TypeResponse<Cart> changeQuantity(CartDTO cartDTO, Principal principal, int quantity) {
-        return null;
-    }
-
-    @Override
     @Transactional
     public TypeResponse<CartResponseDTO> clearCart(Principal principal) {
         try {


### PR DESCRIPTION
- Removed sorting of cart items by creation date and relied on database ordering
- Added @OrderBy annotation to Cart entity to ensure cartItems are ordered by createdAt descending
- Updated pagination logic to use the total count from original items list without sorting
- Fixed page size calculation to prevent zero or negative values
- Cleaned up unused changeQuantity method from ICartService and CartService implementations